### PR TITLE
Update Restore.vb

### DIFF
--- a/UBackup/Restore.vb
+++ b/UBackup/Restore.vb
@@ -162,7 +162,9 @@ Public Class Restore
                     Call Utilities.EnsureDirectory(dboPath)
                     Continue While
                 End If
-                Log.I(LOGNAME & "[DL] " & Path.Combine(dbo.TempFileOrFolderPath, dbo.Name))
+                'BUG HERE - Once line 167 is exec it jumps to exception code if dbo.TempFileOrFolderPath is still null (for some reason?)
+                'TEMP FIX - Line is commented out as its not really required since its just printing to output and code continues as normal after line 167
+                'Log.I(LOGNAME & "[DL] " & Path.Combine(dbo.TempFileOrFolderPath, dbo.Name))
                 Dim tmpGuid As String = dbo.NzbGuid
                 Dim folderPrepare As String = Path.Combine(Utilities.FolderTemp, tmpGuid)
 


### PR DESCRIPTION
Found a bug here if dbo.TempFileOrFolderPath is still null then it jumps to exception code meaning the "Restore" folder ends up with no file in it. I don't really know why it does this maybe something to look into but I have commented out the problem line. 